### PR TITLE
If there was a connection error, it was failing with Ruby 1.9.  See https://github.com/ruby/ruby/blob/v1_9_2_290/lib/net/imap.rb#L3429-3440

### DIFF
--- a/lib/em-imap/connection.rb
+++ b/lib/em-imap/connection.rb
@@ -44,7 +44,7 @@ module EventMachine
           if response.is_a?(Net::IMAP::UntaggedResponse) && response.name != "BYE"
             hello_listener.succeed response
           else
-            hello_listener.fail Net::IMAP::ResponseParseError.new(response.raw_data)
+            hello_listener.fail Net::IMAP::ResponseParseError.new((RUBY_VERSION[0,3] == "1.8" ? response.raw_data : response))
           end
         end.errback do |e|
           hello_listener.fail e
@@ -155,7 +155,7 @@ module EventMachine
         # to hear any more, so we fail all our listeners.
         add_response_handler do |response|
           if response.is_a?(Net::IMAP::UntaggedResponse) && response.name == "BYE"
-            fail Net::IMAP::ByeResponseError.new(response.raw_data)
+            fail Net::IMAP::ByeResponseError.new((RUBY_VERSION[0,3] == "1.8" ? response.raw_data : response))
           end
         end
       end


### PR DESCRIPTION
Make NoResponseError and BadResponseError connection failures compatible with Ruby 1.9
