### PR TITLE
Improve string handling when receiving data

### DIFF
--- a/lib/em-imap/response_parser.rb
+++ b/lib/em-imap/response_parser.rb
@@ -11,7 +11,7 @@ module EventMachine
 
       # This is a translation of Net::IMAP#get_response
       def receive_data(data)
-        @buffer += data
+        @buffer << data
 
         until @buffer.empty?
 


### PR DESCRIPTION
This change reduced fetching a 24Mb email from Gmail from about 10 minutes to 4 seconds.  There may be further optimizations in this method, such as this loop:

while eol && @buffer...

But we're not seeing literals coming with the chunks on large emails.
